### PR TITLE
[codex] Sync receipt extraction API to dev

### DIFF
--- a/src/app/api/receipts/extract/route.ts
+++ b/src/app/api/receipts/extract/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+import {
+  extractReceipt,
+  validateReceiptFile,
+} from "@/lib/receipts/extract";
+import type { ReceiptExtractionError } from "@/lib/receipts/types";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let formData: FormData;
+
+  try {
+    formData = await request.formData();
+  } catch {
+    return extractionError("Upload a receipt file using multipart form data.", 400);
+  }
+
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return extractionError("Receipt file is required.", 400);
+  }
+
+  const validationError = validateReceiptFile(file);
+
+  if (validationError) {
+    return extractionError(validationError, 400);
+  }
+
+  try {
+    const extraction = await extractReceipt(file);
+
+    return NextResponse.json(extraction);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : undefined;
+
+    return extractionError(
+      "Receipt extraction failed. Please try uploading again.",
+      500,
+      details,
+    );
+  }
+}
+
+function extractionError(
+  error: string,
+  status: number,
+  details?: string,
+) {
+  const body: ReceiptExtractionError = {
+    error,
+    ...(details ? { details } : {}),
+  };
+
+  return NextResponse.json(body, { status });
+}

--- a/src/lib/receipts/extract.ts
+++ b/src/lib/receipts/extract.ts
@@ -1,0 +1,153 @@
+import type {
+  ExtractedReceipt,
+  ExtractionConfidence,
+  ReceiptLineItem,
+} from "@/lib/receipts/types";
+
+const MAX_RECEIPT_FILE_SIZE_MB = 20;
+export const MAX_RECEIPT_FILE_SIZE_BYTES = MAX_RECEIPT_FILE_SIZE_MB * 1024 * 1024;
+export const SUPPORTED_RECEIPT_TYPES = new Set([
+  "application/pdf",
+  "image/heic",
+  "image/heif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+export function validateReceiptFile(file: File) {
+  if (!file) {
+    return "Receipt file is required.";
+  }
+
+  if (!isSupportedReceiptFile(file)) {
+    return "Use a receipt photo, screenshot, or PDF.";
+  }
+
+  if (file.size > MAX_RECEIPT_FILE_SIZE_BYTES) {
+    return `Keep the receipt file under ${MAX_RECEIPT_FILE_SIZE_MB} MB.`;
+  }
+
+  return null;
+}
+
+export async function extractReceipt(file: File): Promise<ExtractedReceipt> {
+  const buffer = await file.arrayBuffer();
+
+  return createMockExtraction(file, buffer.byteLength);
+}
+
+function createMockExtraction(file: File, byteLength: number): ExtractedReceipt {
+  const receiptId = crypto.randomUUID();
+  const confidence = confidenceFromFile(file, byteLength);
+  const fileName = file.name.toLowerCase();
+  const storeName = inferStoreName(fileName);
+  const lineItems = inferLineItems(fileName, confidence);
+
+  return {
+    receiptId,
+    sourceFile: {
+      name: file.name,
+      type: file.type || "application/octet-stream",
+      size: file.size,
+    },
+    store: {
+      name: storeName,
+      location: null,
+      confidence: storeName ? "medium" : "low",
+    },
+    purchaseDate: {
+      value: toFranceDate(new Date()),
+      confidence: "low",
+    },
+    lineItems,
+    extractionConfidence: confidence,
+    needsReview: confidence !== "high",
+    extractedAt: new Date().toISOString(),
+    provider: "mock",
+  };
+}
+
+function isSupportedReceiptFile(file: File) {
+  if (SUPPORTED_RECEIPT_TYPES.has(file.type)) {
+    return true;
+  }
+
+  return /\.(heic|heif|jpe?g|pdf|png|webp)$/i.test(file.name);
+}
+
+function confidenceFromFile(file: File, byteLength: number): ExtractionConfidence {
+  if (byteLength > 512_000 && file.type.startsWith("image/")) {
+    return "medium";
+  }
+
+  if (byteLength > 64_000) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function inferStoreName(fileName: string) {
+  if (fileName.includes("carrefour")) {
+    return "Carrefour";
+  }
+
+  if (fileName.includes("monoprix")) {
+    return "Monoprix";
+  }
+
+  if (fileName.includes("leclerc") || fileName.includes("e-leclerc")) {
+    return "E.Leclerc";
+  }
+
+  if (fileName.includes("intermarche") || fileName.includes("intermarch")) {
+    return "Intermarche";
+  }
+
+  return null;
+}
+
+function inferLineItems(
+  fileName: string,
+  confidence: ExtractionConfidence,
+): ReceiptLineItem[] {
+  const items = [
+    createLineItem("Creme de pistache", "Gourmet Celebi", 1, confidence),
+    createLineItem("Jambon blanc", null, 1, "low"),
+    createLineItem("Yaourt nature", null, 2, "low"),
+  ];
+
+  if (fileName.includes("safe") || fileName.includes("clear")) {
+    return [
+      createLineItem("Pates coquillettes", null, 1, "medium"),
+      createLineItem("Lait demi-ecreme", null, 1, "medium"),
+    ];
+  }
+
+  return items;
+}
+
+function createLineItem(
+  name: string,
+  brand: string | null,
+  quantity: number | null,
+  confidence: ExtractionConfidence,
+): ReceiptLineItem {
+  return {
+    id: crypto.randomUUID(),
+    name,
+    brand,
+    quantity,
+    confidence,
+  };
+}
+
+function toFranceDate(date: Date) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}

--- a/src/lib/receipts/types.ts
+++ b/src/lib/receipts/types.ts
@@ -1,0 +1,37 @@
+export type ExtractionConfidence = "high" | "medium" | "low";
+
+export type ReceiptLineItem = {
+  id: string;
+  name: string;
+  brand: string | null;
+  quantity: number | null;
+  confidence: ExtractionConfidence;
+};
+
+export type ExtractedReceipt = {
+  receiptId: string;
+  sourceFile: {
+    name: string;
+    type: string;
+    size: number;
+  };
+  store: {
+    name: string | null;
+    location: string | null;
+    confidence: ExtractionConfidence;
+  };
+  purchaseDate: {
+    value: string | null;
+    confidence: ExtractionConfidence;
+  };
+  lineItems: ReceiptLineItem[];
+  extractionConfidence: ExtractionConfidence;
+  needsReview: boolean;
+  extractedAt: string;
+  provider: "mock";
+};
+
+export type ReceiptExtractionError = {
+  error: string;
+  details?: string;
+};


### PR DESCRIPTION
## Summary

PR #18 for issue #5 was merged into `main`, while `codex/dev` is the validation branch for ongoing work. This PR brings only the approved receipt extraction API files into `codex/dev` without merging `main` wholesale.

## Changes

- Adds `POST /api/receipts/extract`.
- Adds receipt extraction types.
- Adds mock extraction/file validation helper.
- Preserves the already-merged issue #4 upload panel on `codex/dev`.

## Validation

- `bun run lint` passes.
- `bun run build` passes.

## Notes

This is a corrective sync PR so issue #6 can be based on a clean `codex/dev` branch containing both upload UI and extraction API.