### PR TITLE
[codex] Add extraction review step

### DIFF
--- a/src/components/receipt/extraction-review.tsx
+++ b/src/components/receipt/extraction-review.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import * as React from "react";
+import { CalendarDays, Plus, Store, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type {
+  ExtractedReceipt,
+  ExtractionConfidence,
+  ReceiptLineItem,
+} from "@/lib/receipts/types";
+import { cn } from "@/lib/utils";
+
+type ExtractionReviewProps = {
+  extraction: ExtractedReceipt;
+  onBack: () => void;
+};
+
+export function ExtractionReview({
+  extraction,
+  onBack,
+}: ExtractionReviewProps) {
+  const [storeName, setStoreName] = React.useState(extraction.store.name ?? "");
+  const [purchaseDate, setPurchaseDate] = React.useState(
+    extraction.purchaseDate.value ?? "",
+  );
+  const [lineItems, setLineItems] = React.useState(extraction.lineItems);
+
+  function updateLineItem(id: string, changes: Partial<ReceiptLineItem>) {
+    setLineItems((items) =>
+      items.map((item) => (item.id === id ? { ...item, ...changes } : item)),
+    );
+  }
+
+  function addLineItem() {
+    setLineItems((items) => [
+      ...items,
+      {
+        id: crypto.randomUUID(),
+        name: "",
+        brand: null,
+        quantity: null,
+        confidence: "low",
+      },
+    ]);
+  }
+
+  function removeLineItem(id: string) {
+    setLineItems((items) => items.filter((item) => item.id !== id));
+  }
+
+  return (
+    <section className="space-y-5 rounded-lg border border-border bg-card p-5 shadow-sm">
+      <div>
+        <p className="text-sm font-medium text-primary">Extraction review</p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight">
+          Check what we found
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Edit the store, purchase date, or receipt items before recall
+          matching runs.
+        </p>
+      </div>
+
+      <ConfidenceNotice confidence={extraction.extractionConfidence} />
+
+      <div className="grid gap-4">
+        <label className="grid gap-2">
+          <span className="flex items-center gap-2 text-sm font-medium">
+            <Store aria-hidden="true" className="size-4 text-muted-foreground" />
+            Store
+            <ConfidenceBadge confidence={extraction.store.confidence} />
+          </span>
+          <input
+            className="min-h-11 rounded-lg border border-input bg-background px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+            onChange={(event) => setStoreName(event.target.value)}
+            placeholder="Store name"
+            value={storeName}
+          />
+        </label>
+
+        <label className="grid gap-2">
+          <span className="flex items-center gap-2 text-sm font-medium">
+            <CalendarDays
+              aria-hidden="true"
+              className="size-4 text-muted-foreground"
+            />
+            Purchase date
+            <ConfidenceBadge confidence={extraction.purchaseDate.confidence} />
+          </span>
+          <input
+            className="min-h-11 rounded-lg border border-input bg-background px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+            onChange={(event) => setPurchaseDate(event.target.value)}
+            type="date"
+            value={purchaseDate}
+          />
+        </label>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="font-semibold">Line items</h3>
+          <Button onClick={addLineItem} size="sm" type="button" variant="outline">
+            <Plus aria-hidden="true" />
+            Add
+          </Button>
+        </div>
+
+        <div className="grid gap-3">
+          {lineItems.map((item, index) => (
+            <LineItemEditor
+              index={index}
+              item={item}
+              key={item.id}
+              onRemove={() => removeLineItem(item.id)}
+              onUpdate={(changes) => updateLineItem(item.id, changes)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-3 pt-2">
+        <Button className="h-12" type="button">
+          Continue to recall matching
+        </Button>
+        <Button className="h-12" onClick={onBack} type="button" variant="ghost">
+          Back to receipt upload
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function LineItemEditor({
+  index,
+  item,
+  onRemove,
+  onUpdate,
+}: {
+  index: number;
+  item: ReceiptLineItem;
+  onRemove: () => void;
+  onUpdate: (changes: Partial<ReceiptLineItem>) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background p-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="text-sm font-medium text-muted-foreground">
+          Item {index + 1}
+        </div>
+        <div className="flex items-center gap-2">
+          <ConfidenceBadge confidence={item.confidence} />
+          <Button
+            aria-label={`Remove item ${index + 1}`}
+            onClick={onRemove}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Trash2 aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3">
+        <label className="grid gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            Product name
+          </span>
+          <input
+            className="min-h-11 rounded-lg border border-input bg-card px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+            onChange={(event) => onUpdate({ name: event.target.value })}
+            placeholder="Product name"
+            value={item.name}
+          />
+        </label>
+
+        <div className="grid grid-cols-[1fr_96px] gap-3">
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Brand
+            </span>
+            <input
+              className="min-h-11 rounded-lg border border-input bg-card px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+              onChange={(event) =>
+                onUpdate({ brand: event.target.value || null })
+              }
+              placeholder="Optional"
+              value={item.brand ?? ""}
+            />
+          </label>
+
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Qty
+            </span>
+            <input
+              className="min-h-11 rounded-lg border border-input bg-card px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+              min="0"
+              onChange={(event) =>
+                onUpdate({
+                  quantity: event.target.value
+                    ? Number.parseFloat(event.target.value)
+                    : null,
+                })
+              }
+              placeholder="1"
+              type="number"
+              value={item.quantity ?? ""}
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfidenceNotice({
+  confidence,
+}: {
+  confidence: ExtractionConfidence;
+}) {
+  if (confidence === "high") {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border border-caution/30 bg-caution/10 p-3 text-sm leading-6 text-caution">
+      Some fields may need review before recall matching. Receipt descriptions
+      can be abbreviated, especially on grocery receipts.
+    </div>
+  );
+}
+
+function ConfidenceBadge({
+  confidence,
+}: {
+  confidence: ExtractionConfidence;
+}) {
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 text-xs font-medium capitalize",
+        confidence === "high" && "bg-success/15 text-success",
+        confidence === "medium" && "bg-caution/15 text-caution",
+        confidence === "low" && "bg-muted text-muted-foreground",
+      )}
+    >
+      {confidence}
+    </span>
+  );
+}

--- a/src/components/receipt/upload-panel.tsx
+++ b/src/components/receipt/upload-panel.tsx
@@ -14,6 +14,8 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ExtractionReview } from "@/components/receipt/extraction-review";
+import type { ExtractedReceipt } from "@/lib/receipts/types";
 import { cn } from "@/lib/utils";
 
 const ACCEPTED_FILE_TYPES = "image/*,.pdf";
@@ -31,6 +33,10 @@ export function UploadPanel() {
   const [selectedReceipt, setSelectedReceipt] =
     React.useState<SelectedReceipt | null>(null);
   const [isPreparing, setIsPreparing] = React.useState(false);
+  const [isExtracting, setIsExtracting] = React.useState(false);
+  const [extraction, setExtraction] = React.useState<ExtractedReceipt | null>(
+    null,
+  );
   const [isDragging, setIsDragging] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -50,6 +56,7 @@ export function UploadPanel() {
     }
 
     setError(null);
+    setExtraction(null);
 
     if (!isSupportedFile(file)) {
       setError("Use a receipt photo, screenshot, or PDF.");
@@ -89,6 +96,7 @@ export function UploadPanel() {
       return null;
     });
     setError(null);
+    setExtraction(null);
 
     if (cameraInputRef.current) {
       cameraInputRef.current.value = "";
@@ -97,6 +105,55 @@ export function UploadPanel() {
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
+  }
+
+  async function extractSelectedReceipt() {
+    if (!selectedReceipt) {
+      return;
+    }
+
+    setError(null);
+    setIsExtracting(true);
+
+    const formData = new FormData();
+    formData.set("file", selectedReceipt.file);
+
+    try {
+      const response = await fetch("/api/receipts/extract", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+
+        throw new Error(
+          body?.error ?? "Receipt extraction failed. Please try again.",
+        );
+      }
+
+      const nextExtraction = (await response.json()) as ExtractedReceipt;
+      setExtraction(nextExtraction);
+    } catch (extractError) {
+      setError(
+        extractError instanceof Error
+          ? extractError.message
+          : "Receipt extraction failed. Please try again.",
+      );
+    } finally {
+      setIsExtracting(false);
+    }
+  }
+
+  if (extraction) {
+    return (
+      <ExtractionReview
+        extraction={extraction}
+        onBack={() => setExtraction(null)}
+      />
+    );
   }
 
   return (
@@ -134,6 +191,8 @@ export function UploadPanel() {
       >
         {selectedReceipt ? (
           <SelectedFileCard
+            isExtracting={isExtracting}
+            onContinue={extractSelectedReceipt}
             receipt={selectedReceipt}
             onClear={clearSelection}
           />
@@ -225,9 +284,13 @@ function EmptyUploadState({ isPreparing }: { isPreparing: boolean }) {
 }
 
 function SelectedFileCard({
+  isExtracting,
+  onContinue,
   receipt,
   onClear,
 }: {
+  isExtracting: boolean;
+  onContinue: () => void;
   receipt: SelectedReceipt;
   onClear: () => void;
 }) {
@@ -266,9 +329,18 @@ function SelectedFileCard({
         </Button>
       </div>
 
-      <Button className="h-12 w-full" type="button">
-        <RotateCcw aria-hidden="true" />
-        Continue to extraction
+      <Button
+        className="h-12 w-full"
+        disabled={isExtracting}
+        onClick={onContinue}
+        type="button"
+      >
+        {isExtracting ? (
+          <Loader2 aria-hidden="true" className="animate-spin" />
+        ) : (
+          <RotateCcw aria-hidden="true" />
+        )}
+        {isExtracting ? "Extracting receipt..." : "Continue to extraction"}
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds the editable extraction review step after receipt upload and extraction.

## Changes

- Wires `UploadPanel` to call `POST /api/receipts/extract` with the selected file.
- Adds loading state while extraction runs.
- Adds error handling for extraction failures.
- Adds `ExtractionReview` component for reviewing extracted store, purchase date, and line items.
- Adds editable store name and purchase date fields.
- Adds editable line items with product name, brand, quantity, and confidence badges.
- Adds add/remove line item controls.
- Adds confidence warning copy when extraction is not high confidence.
- Adds placeholder `Continue to recall matching` action for the next matching step.

## Validation

- `bun run lint` passes.
- `bun run build` passes.
- `bun dev` starts successfully. Port 3000 was occupied locally during validation, so Next used 3001.

## Testing Notes

Run `bun dev`, open `/check`, select an image/PDF receipt, click `Continue to extraction`, then verify the review form appears and fields/items can be edited, added, removed, and navigated back to upload.