### PR TITLE
Add receipt processing flow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,3 +106,19 @@ select,
 textarea {
   -webkit-tap-highlight-color: transparent;
 }
+
+@keyframes receipt-product-fade {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@utility animate-receipt-product-fade {
+  animation: receipt-product-fade 0.35s ease forwards;
+}

--- a/src/components/receipt/extraction-review.tsx
+++ b/src/components/receipt/extraction-review.tsx
@@ -5,12 +5,12 @@ import {
   AlertTriangle,
   CalendarDays,
   CheckCircle2,
-  Loader2,
   Plus,
   Store,
   Trash2,
 } from "lucide-react";
 
+import { ProcessingIndicator } from "@/components/receipt/processing-indicator";
 import { Button } from "@/components/ui/button";
 import type { RecallMatchingResult } from "@/lib/recalls/matching";
 import type {
@@ -19,6 +19,8 @@ import type {
   ReceiptLineItem,
 } from "@/lib/receipts/types";
 import { cn } from "@/lib/utils";
+
+type ProcessingStage = "matching" | "preparing";
 
 type ExtractionReviewProps = {
   extraction: ExtractedReceipt;
@@ -34,7 +36,8 @@ export function ExtractionReview({
     extraction.purchaseDate.value ?? "",
   );
   const [lineItems, setLineItems] = React.useState(extraction.lineItems);
-  const [isMatching, setIsMatching] = React.useState(false);
+  const [processingStage, setProcessingStage] =
+    React.useState<ProcessingStage | null>(null);
   const [matchResult, setMatchResult] =
     React.useState<RecallMatchingResult | null>(null);
   const [matchError, setMatchError] = React.useState<string | null>(null);
@@ -72,28 +75,31 @@ export function ExtractionReview({
       return;
     }
 
-    setIsMatching(true);
+    setProcessingStage("matching");
     setMatchError(null);
     setMatchResult(null);
 
     try {
-      const response = await fetch("/api/recalls/match", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          receipt: {
-            receiptId: extraction.receiptId,
-            store: {
-              name: storeName.trim() || null,
-              location: extraction.store.location,
-            },
-            purchaseDate: purchaseDate || null,
-            lineItems: cleanLineItems,
+      const response = await Promise.all([
+        fetch("/api/recalls/match", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
           },
+          body: JSON.stringify({
+            receipt: {
+              receiptId: extraction.receiptId,
+              store: {
+                name: storeName.trim() || null,
+                location: extraction.store.location,
+              },
+              purchaseDate: purchaseDate || null,
+              lineItems: cleanLineItems,
+            },
+          }),
         }),
-      });
+        wait(900),
+      ]).then(([matchResponse]) => matchResponse);
 
       if (!response.ok) {
         const body = (await response.json().catch(() => null)) as {
@@ -106,6 +112,8 @@ export function ExtractionReview({
       }
 
       const nextMatchResult = (await response.json()) as RecallMatchingResult;
+      setProcessingStage("preparing");
+      await wait(500);
       setMatchResult(nextMatchResult);
     } catch (error) {
       setMatchError(
@@ -114,8 +122,12 @@ export function ExtractionReview({
           : "Recall matching failed. Please try again.",
       );
     } finally {
-      setIsMatching(false);
+      setProcessingStage(null);
     }
+  }
+
+  if (processingStage) {
+    return <ProcessingIndicator items={lineItems} stage={processingStage} />;
   }
 
   return (
@@ -199,14 +211,11 @@ export function ExtractionReview({
       <div className="grid gap-3 pt-2">
         <Button
           className="h-12"
-          disabled={isMatching}
+          disabled={Boolean(processingStage)}
           onClick={continueToRecallMatching}
           type="button"
         >
-          {isMatching ? (
-            <Loader2 aria-hidden="true" className="animate-spin" />
-          ) : null}
-          {isMatching ? "Matching recalls..." : "Continue to recall matching"}
+          Continue to recall matching
         </Button>
         <Button className="h-12" onClick={onBack} type="button" variant="ghost">
           Back to receipt upload
@@ -214,6 +223,10 @@ export function ExtractionReview({
       </div>
     </section>
   );
+}
+
+function wait(duration: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, duration));
 }
 
 function MatchingSummary({ result }: { result: RecallMatchingResult }) {

--- a/src/components/receipt/processing-indicator.tsx
+++ b/src/components/receipt/processing-indicator.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import { Check, FileText, Search } from "lucide-react";
+
+import type { ReceiptLineItem } from "@/lib/receipts/types";
+import { cn } from "@/lib/utils";
+
+type ProcessingStage = "matching" | "preparing";
+
+type ProcessingIndicatorProps = {
+  items: ReceiptLineItem[];
+  stage: ProcessingStage;
+};
+
+const visibleItemLimit = 8;
+
+export function ProcessingIndicator({
+  items,
+  stage,
+}: ProcessingIndicatorProps) {
+  const visibleItems = items.slice(0, visibleItemLimit);
+  const extraCount = Math.max(0, items.length - visibleItemLimit);
+
+  return (
+    <section className="min-h-[calc(100svh-9rem)] rounded-lg border border-border bg-card px-5 py-8 shadow-sm">
+      <div className="text-center">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Analyse en cours
+        </h2>
+        <p className="mt-2 font-mono text-xs text-muted-foreground">
+          Lecture du ticket et verification des rappels
+        </p>
+      </div>
+
+      <div
+        aria-label="Analyse en cours"
+        className="mx-auto mt-12 size-12 animate-spin rounded-full border-[3px] border-border border-t-primary"
+        role="status"
+      />
+
+      <div className="mt-10 space-y-1">
+        <ProcessingStep
+          detail={`${items.length} produit${items.length > 1 ? "s" : ""} identifie${
+            items.length > 1 ? "s" : ""
+          }`}
+          label="Ticket lu"
+          state="done"
+        />
+        <ProcessingStep
+          detail="Comparaison avec la base RappelConso"
+          label="Verification des rappels"
+          state={stage === "matching" ? "active" : "done"}
+        />
+        <ProcessingStep
+          detail="Preparation du rapport"
+          label="Resultats"
+          state={stage === "preparing" ? "active" : "pending"}
+        />
+      </div>
+
+      <section className="mt-8">
+        <p className="mb-3 font-mono text-xs uppercase text-muted-foreground">
+          Produits identifies
+        </p>
+        <div className="space-y-2">
+          {visibleItems.map((item, index) => (
+            <div
+              className="animate-receipt-product-fade flex min-h-12 items-center gap-3 rounded-lg border border-border bg-background px-4 opacity-0"
+              key={item.id}
+              style={{ animationDelay: `${0.18 + index * 0.12}s` }}
+            >
+              <span className="size-2 shrink-0 rounded-full bg-success" />
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                {item.name}
+              </span>
+              <span className="shrink-0 font-mono text-[11px] font-medium uppercase text-success">
+                Verifie
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {extraCount ? (
+          <p className="mt-3 text-center font-mono text-xs text-muted-foreground">
+            + {extraCount} autres produits
+          </p>
+        ) : null}
+      </section>
+    </section>
+  );
+}
+
+function ProcessingStep({
+  detail,
+  label,
+  state,
+}: {
+  detail: string;
+  label: string;
+  state: "done" | "active" | "pending";
+}) {
+  return (
+    <div className="flex items-center gap-3 py-3">
+      <div
+        className={cn(
+          "grid size-9 shrink-0 place-items-center rounded-full",
+          state === "done" && "bg-success text-success-foreground",
+          state === "active" && "bg-accent text-primary",
+          state === "pending" && "bg-muted text-muted-foreground",
+        )}
+      >
+        {state === "done" ? (
+          <Check aria-hidden="true" className="size-5" />
+        ) : state === "active" ? (
+          <Search aria-hidden="true" className="size-5" />
+        ) : (
+          <FileText aria-hidden="true" className="size-5" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "text-sm font-medium",
+            state === "pending" && "text-muted-foreground",
+          )}
+        >
+          {label}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a mobile-first processing indicator matching the V1 three-step flow: ticket read, recall verification, results preparation
- show the active spinner plus staggered product list while recall matching runs
- transition the review CTA through matching/preparing states before showing the existing interim match summary

Closes #9

## Validation
- bun run lint
- bun run build
- started `bun dev`; `/check` returned HTTP 200 at `http://localhost:3001/check`