### PR TITLE
Add analysis result states

### DIFF
--- a/src/components/receipt/analysis-result.tsx
+++ b/src/components/receipt/analysis-result.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  RotateCcw,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type {
+  MatchedReceiptItem,
+  RecallMatchingResult,
+} from "@/lib/recalls/matching";
+import { cn } from "@/lib/utils";
+
+type AnalysisResultProps = {
+  result: RecallMatchingResult;
+  onScanAnother: () => void;
+};
+
+const visibleSafeItemLimit = 5;
+
+export function AnalysisResult({
+  result,
+  onScanAnother,
+}: AnalysisResultProps) {
+  const flaggedItems = result.items.filter((item) => item.confidence !== "none");
+  const safeItems = result.items.filter((item) => item.confidence === "none");
+  const hasWarnings = flaggedItems.length > 0;
+  const totalPrice = result.items.reduce(
+    (total, item) => total + (item.item.price ?? 0),
+    0,
+  );
+
+  return (
+    <section className="space-y-5">
+      <div className="rounded-lg border border-border bg-card p-5 text-center shadow-sm">
+        <div
+          className={cn(
+            "mx-auto grid size-20 place-items-center rounded-full border-2",
+            hasWarnings
+              ? "border-risk bg-risk/10 text-risk"
+              : "border-success bg-success/10 text-success",
+          )}
+        >
+          {hasWarnings ? (
+            <AlertTriangle aria-hidden="true" className="size-9" />
+          ) : (
+            <Check aria-hidden="true" className="size-9" />
+          )}
+        </div>
+
+        <h2
+          className={cn(
+            "mt-5 text-2xl font-semibold tracking-tight",
+            hasWarnings && "text-risk",
+          )}
+        >
+          {hasWarnings ? "Produit à vérifier" : "Tout est clair"}
+        </h2>
+        <p className="mx-auto mt-2 max-w-xs text-sm leading-6 text-muted-foreground">
+          {hasWarnings
+            ? "Un produit peut correspondre à un rappel en cours. Vérifiez avant de consommer."
+            : "Aucun rappel actif ne concerne les produits de ce ticket."}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2.5">
+        <SummaryStat
+          label="Verifies"
+          tone="success"
+          value={safeItems.length.toString()}
+        />
+        <SummaryStat
+          label={hasWarnings ? "À vérifier" : "Alertes"}
+          tone={hasWarnings ? "risk" : "default"}
+          value={flaggedItems.length.toString()}
+        />
+        <SummaryStat label="Total" value={formatPrice(totalPrice)} />
+      </div>
+
+      {hasWarnings ? <FlaggedItems items={flaggedItems} /> : null}
+
+      <SafeProducts items={hasWarnings ? safeItems : result.items} />
+
+      <div className="grid gap-3 pt-1">
+        <Button className="h-12" onClick={onScanAnother} type="button">
+          <RotateCcw aria-hidden="true" />
+          Scanner un autre ticket
+        </Button>
+
+        {!hasWarnings ? (
+          <Button asChild className="h-12" variant="outline">
+            <Link href="/">Retour à l&apos;accueil</Link>
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function SummaryStat({
+  label,
+  tone = "default",
+  value,
+}: {
+  label: string;
+  tone?: "default" | "risk" | "success";
+  value: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border bg-card px-2 py-3 text-center shadow-sm",
+        tone === "risk" && "border-risk/30 bg-risk/10",
+      )}
+    >
+      <div
+        className={cn(
+          "font-mono text-xl font-semibold tabular-nums",
+          tone === "success" && "text-success",
+          tone === "risk" && "text-risk",
+        )}
+      >
+        {value}
+      </div>
+      <div
+        className={cn(
+          "mt-1 font-mono text-[11px] text-muted-foreground",
+          tone === "risk" && "text-risk",
+        )}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function FlaggedItems({ items }: { items: MatchedReceiptItem[] }) {
+  return (
+    <section>
+      <p className="mb-3 font-mono text-xs uppercase text-risk">À vérifier</p>
+      <div className="space-y-3">
+        {items.map((item) => {
+          const topMatch = item.matches[0];
+
+          return (
+            <button
+              className="flex w-full items-center gap-3 rounded-lg border border-risk/20 bg-risk/10 p-3 text-left"
+              key={item.item.id}
+              type="button"
+            >
+              <span className="grid size-10 shrink-0 place-items-center rounded-lg border border-risk/20 bg-card text-risk">
+                <AlertTriangle aria-hidden="true" className="size-5" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold">
+                  {item.item.name}
+                </span>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                  {confidenceLabel(item.confidence)}
+                  {topMatch?.recall.brand ? ` · ${topMatch.recall.brand}` : ""}
+                </span>
+                <span className="mt-1 block text-xs font-medium text-risk">
+                  Voir les détails du rappel
+                </span>
+              </span>
+              <ChevronRight
+                aria-hidden="true"
+                className="size-5 shrink-0 text-muted-foreground"
+              />
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function SafeProducts({ items }: { items: MatchedReceiptItem[] }) {
+  const visibleItems = items.slice(0, visibleSafeItemLimit);
+  const extraCount = Math.max(0, items.length - visibleSafeItemLimit);
+
+  return (
+    <section>
+      <p className="mb-3 font-mono text-xs uppercase text-muted-foreground">
+        Produits vérifiés
+      </p>
+      <div className="rounded-lg border border-border bg-card px-4 py-1 shadow-sm">
+        {visibleItems.map((item) => (
+          <div
+            className="flex min-h-11 items-center gap-3 border-t border-border first:border-t-0"
+            key={item.item.id}
+          >
+            <span className="size-2 shrink-0 rounded-full bg-success" />
+            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+              {item.item.name}
+            </span>
+            {item.item.price !== null ? (
+              <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                {formatPrice(item.item.price)}
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      {extraCount ? (
+        <p className="mt-3 text-center text-sm text-muted-foreground">
+          + {extraCount} autres produits vérifiés
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function confidenceLabel(confidence: MatchedReceiptItem["confidence"]) {
+  if (confidence === "strong") {
+    return "Correspondance forte";
+  }
+
+  if (confidence === "needs_verification") {
+    return "Vérification nécessaire";
+  }
+
+  return "Correspondance possible";
+}
+
+function formatPrice(value: number) {
+  return new Intl.NumberFormat("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}

--- a/src/components/receipt/extraction-review.tsx
+++ b/src/components/receipt/extraction-review.tsx
@@ -2,14 +2,13 @@
 
 import * as React from "react";
 import {
-  AlertTriangle,
   CalendarDays,
-  CheckCircle2,
   Plus,
   Store,
   Trash2,
 } from "lucide-react";
 
+import { AnalysisResult } from "@/components/receipt/analysis-result";
 import { ProcessingIndicator } from "@/components/receipt/processing-indicator";
 import { Button } from "@/components/ui/button";
 import type { RecallMatchingResult } from "@/lib/recalls/matching";
@@ -56,6 +55,7 @@ export function ExtractionReview({
         name: "",
         brand: null,
         quantity: null,
+        price: null,
         confidence: "low",
       },
     ]);
@@ -130,6 +130,10 @@ export function ExtractionReview({
     return <ProcessingIndicator items={lineItems} stage={processingStage} />;
   }
 
+  if (matchResult) {
+    return <AnalysisResult onScanAnother={onBack} result={matchResult} />;
+  }
+
   return (
     <section className="space-y-5 rounded-lg border border-border bg-card p-5 shadow-sm">
       <div>
@@ -144,8 +148,6 @@ export function ExtractionReview({
       </div>
 
       <ConfidenceNotice confidence={extraction.extractionConfidence} />
-
-      {matchResult ? <MatchingSummary result={matchResult} /> : null}
 
       {matchError ? (
         <p className="rounded-lg bg-risk/10 px-3 py-2 text-sm font-medium text-risk">
@@ -229,40 +231,6 @@ function wait(duration: number) {
   return new Promise((resolve) => window.setTimeout(resolve, duration));
 }
 
-function MatchingSummary({ result }: { result: RecallMatchingResult }) {
-  const hasFlaggedItems = result.summary.flagged > 0;
-
-  return (
-    <div
-      className={cn(
-        "rounded-lg border p-3 text-sm leading-6",
-        hasFlaggedItems
-          ? "border-risk/30 bg-risk/10 text-risk"
-          : "border-success/30 bg-success/10 text-success",
-      )}
-    >
-      <div className="flex items-start gap-2 font-medium">
-        {hasFlaggedItems ? (
-          <AlertTriangle aria-hidden="true" className="mt-0.5 size-4" />
-        ) : (
-          <CheckCircle2 aria-hidden="true" className="mt-0.5 size-4" />
-        )}
-        <p>
-          {hasFlaggedItems
-            ? `${result.summary.flagged} product${
-                result.summary.flagged > 1 ? "s" : ""
-              } may need verification.`
-            : "No relevant active recall match found."}
-        </p>
-      </div>
-      <p className="mt-2 text-xs opacity-80">
-        Compared {result.summary.totalItems} receipt items with{" "}
-        {result.recallCount} active RappelConso recalls.
-      </p>
-    </div>
-  );
-}
-
 function LineItemEditor({
   index,
   item,
@@ -307,7 +275,7 @@ function LineItemEditor({
           />
         </label>
 
-        <div className="grid grid-cols-[1fr_96px] gap-3">
+        <div className="grid grid-cols-[1fr_82px_82px] gap-3">
           <label className="grid gap-1.5">
             <span className="text-xs font-medium text-muted-foreground">
               Brand
@@ -339,6 +307,27 @@ function LineItemEditor({
               placeholder="1"
               type="number"
               value={item.quantity ?? ""}
+            />
+          </label>
+
+          <label className="grid gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Price
+            </span>
+            <input
+              className="min-h-11 rounded-lg border border-input bg-card px-3 text-base outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20"
+              min="0"
+              onChange={(event) =>
+                onUpdate({
+                  price: event.target.value
+                    ? Number.parseFloat(event.target.value)
+                    : null,
+                })
+              }
+              placeholder="0.00"
+              step="0.01"
+              type="number"
+              value={item.price ?? ""}
             />
           </label>
         </div>

--- a/src/lib/receipts/extract.ts
+++ b/src/lib/receipts/extract.ts
@@ -113,15 +113,15 @@ function inferLineItems(
   confidence: ExtractionConfidence,
 ): ReceiptLineItem[] {
   const items = [
-    createLineItem("Creme de pistache", "Gourmet Celebi", 1, confidence),
-    createLineItem("Jambon blanc", null, 1, "low"),
-    createLineItem("Yaourt nature", null, 2, "low"),
+    createLineItem("Creme de pistache", "Gourmet Celebi", 1, 4.99, confidence),
+    createLineItem("Jambon blanc", null, 1, 2.35, "low"),
+    createLineItem("Yaourt nature", null, 2, 1.8, "low"),
   ];
 
   if (fileName.includes("safe") || fileName.includes("clear")) {
     return [
-      createLineItem("Pates coquillettes", null, 1, "medium"),
-      createLineItem("Lait demi-ecreme", null, 1, "medium"),
+      createLineItem("Pates coquillettes", null, 1, 1.49, "medium"),
+      createLineItem("Lait demi-ecreme", null, 1, 1.15, "medium"),
     ];
   }
 
@@ -132,6 +132,7 @@ function createLineItem(
   name: string,
   brand: string | null,
   quantity: number | null,
+  price: number | null,
   confidence: ExtractionConfidence,
 ): ReceiptLineItem {
   return {
@@ -139,6 +140,7 @@ function createLineItem(
     name,
     brand,
     quantity,
+    price,
     confidence,
   };
 }

--- a/src/lib/receipts/types.ts
+++ b/src/lib/receipts/types.ts
@@ -5,6 +5,7 @@ export type ReceiptLineItem = {
   name: string;
   brand: string | null;
   quantity: number | null;
+  price: number | null;
   confidence: ExtractionConfidence;
 };
 


### PR DESCRIPTION
## Summary
- add the mobile safe/warning analysis result component with hero status, stats grid, flagged item cards, safe product list, and CTAs
- wire matching completion to the result screen instead of the interim summary
- carry optional receipt item prices through extraction and review so totals/prices can render in results

Closes #10

## Validation
- bun run lint
- bun run build
- started `bun dev`; `/check` returned HTTP 200 at `http://localhost:3001/check`

## Note
- Flagged item cards are tappable UI shells for now; issue #11 will add the actual recall detail route/screen.