### PR TITLE
Add recall detail and history flow

### DIFF
--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -1,34 +1,195 @@
-const statuses = ["All", "To verify", "Affected", "Verified safe", "Ignored"];
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { AnalysisResult } from "@/components/receipt/analysis-result";
+import type { SavedReceiptCheck } from "@/lib/receipts/history";
+import {
+  getReceiptHistoryServerSnapshot,
+  readReceiptChecks,
+  subscribeToReceiptHistory,
+} from "@/lib/receipts/history";
+import { cn } from "@/lib/utils";
+
+const filters = [
+  { value: "all", label: "Tous" },
+  { value: "alerts", label: "Alertes" },
+  { value: "month", label: "Ce mois" },
+] as const;
+
+type HistoryFilter = (typeof filters)[number]["value"];
 
 export default function HistoryPage() {
+  const checks = React.useSyncExternalStore(
+    subscribeToReceiptHistory,
+    readReceiptChecks,
+    getReceiptHistoryServerSnapshot,
+  );
+  const [activeFilter, setActiveFilter] = React.useState<HistoryFilter>("all");
+  const [selectedCheck, setSelectedCheck] =
+    React.useState<SavedReceiptCheck | null>(null);
+  const visibleChecks = filterChecks(checks, activeFilter);
+
+  if (selectedCheck) {
+    return (
+      <AnalysisResult
+        onScanAnother={() => setSelectedCheck(null)}
+        result={selectedCheck.result}
+      />
+    );
+  }
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <section>
-        <p className="text-sm font-medium text-primary">History</p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight">
-          Past receipt checks
-        </h2>
-        <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          This tab will list imported receipts, flagged items, and saved
-          verification statuses.
-        </p>
+        <h2 className="text-2xl font-semibold tracking-tight">Historique</h2>
       </section>
 
-      <div className="flex gap-2 overflow-x-auto pb-2">
-        {statuses.map((status) => (
-          <button
-            className="min-h-11 shrink-0 rounded-lg border border-border bg-card px-3 text-sm font-medium text-muted-foreground first:bg-accent first:text-accent-foreground"
-            key={status}
-            type="button"
-          >
-            {status}
-          </button>
-        ))}
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {filters.map((filter) => {
+          const isActive = activeFilter === filter.value;
+
+          return (
+            <button
+              className={cn(
+                "min-h-9 shrink-0 rounded-full border px-4 text-sm font-medium transition-colors",
+                isActive
+                  ? "border-transparent bg-primary text-primary-foreground"
+                  : "border-border bg-card text-muted-foreground",
+              )}
+              key={filter.value}
+              onClick={() => setActiveFilter(filter.value)}
+              type="button"
+            >
+              {filter.label}
+            </button>
+          );
+        })}
       </div>
 
-      <div className="rounded-lg border border-dashed border-border bg-card p-5 text-sm leading-6 text-muted-foreground">
-        No receipt history yet.
-      </div>
+      {visibleChecks.length > 0 ? (
+        <section className="space-y-3">
+          {visibleChecks.map((check) => (
+            <HistoryItem
+              check={check}
+              key={check.id}
+              onSelect={() => setSelectedCheck(check)}
+            />
+          ))}
+        </section>
+      ) : (
+        <div className="rounded-lg border border-dashed border-border bg-card p-5 text-sm leading-6 text-muted-foreground">
+          Aucun ticket dans cet historique pour le moment.
+        </div>
+      )}
     </div>
   );
+}
+
+function HistoryItem({
+  check,
+  onSelect,
+}: {
+  check: SavedReceiptCheck;
+  onSelect: () => void;
+}) {
+  const flaggedCount = check.result.summary.flagged;
+  const isFlagged = flaggedCount > 0;
+
+  return (
+    <button
+      className="grid w-full grid-cols-[1fr_auto] items-start gap-3 rounded-lg border border-border bg-card p-4 text-left shadow-sm"
+      onClick={onSelect}
+      type="button"
+    >
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-semibold">
+          {check.storeName || "Magasin non identifié"}
+        </span>
+        <span className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span>
+            {check.result.summary.totalItems} produit
+            {check.result.summary.totalItems > 1 ? "s" : ""}
+          </span>
+          <span>·</span>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 font-medium",
+              isFlagged ? "text-risk" : "text-success",
+            )}
+          >
+            {isFlagged ? (
+              <AlertTriangle aria-hidden="true" className="size-3" />
+            ) : (
+              <CheckCircle2 aria-hidden="true" className="size-3" />
+            )}
+            {isFlagged
+              ? `${flaggedCount} à vérifier`
+              : "Aucun rappel"}
+          </span>
+        </span>
+      </span>
+      <span className="pt-0.5 font-mono text-xs text-muted-foreground">
+        {relativeDate(check.createdAt)}
+      </span>
+    </button>
+  );
+}
+
+function filterChecks(checks: SavedReceiptCheck[], filter: HistoryFilter) {
+  if (filter === "alerts") {
+    return checks.filter((check) => check.result.summary.flagged > 0);
+  }
+
+  if (filter === "month") {
+    const now = new Date();
+
+    return checks.filter((check) => {
+      const createdAt = new Date(check.createdAt);
+
+      return (
+        createdAt.getMonth() === now.getMonth() &&
+        createdAt.getFullYear() === now.getFullYear()
+      );
+    });
+  }
+
+  return checks;
+}
+
+function relativeDate(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const now = new Date();
+  const startToday = startOfDay(now).getTime();
+  const startDate = startOfDay(date).getTime();
+  const daysAgo = Math.round((startToday - startDate) / 86_400_000);
+
+  if (daysAgo === 0) {
+    return "Aujourd'hui";
+  }
+
+  if (daysAgo === 1) {
+    return "Hier";
+  }
+
+  if (daysAgo < 7) {
+    return new Intl.DateTimeFormat("fr-FR", {
+      weekday: "short",
+    }).format(date);
+  }
+
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "short",
+  }).format(date);
+}
+
+function startOfDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }

--- a/src/components/receipt/analysis-result.tsx
+++ b/src/components/receipt/analysis-result.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
@@ -8,6 +9,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 
+import { RecallDetail } from "@/components/receipt/recall-detail";
 import { Button } from "@/components/ui/button";
 import type {
   MatchedReceiptItem,
@@ -26,6 +28,8 @@ export function AnalysisResult({
   result,
   onScanAnother,
 }: AnalysisResultProps) {
+  const [selectedItem, setSelectedItem] =
+    React.useState<MatchedReceiptItem | null>(null);
   const flaggedItems = result.items.filter((item) => item.confidence !== "none");
   const safeItems = result.items.filter((item) => item.confidence === "none");
   const hasWarnings = flaggedItems.length > 0;
@@ -33,6 +37,15 @@ export function AnalysisResult({
     (total, item) => total + (item.item.price ?? 0),
     0,
   );
+
+  if (selectedItem) {
+    return (
+      <RecallDetail
+        matchedItem={selectedItem}
+        onBack={() => setSelectedItem(null)}
+      />
+    );
+  }
 
   return (
     <section className="space-y-5">
@@ -81,7 +94,9 @@ export function AnalysisResult({
         <SummaryStat label="Total" value={formatPrice(totalPrice)} />
       </div>
 
-      {hasWarnings ? <FlaggedItems items={flaggedItems} /> : null}
+      {hasWarnings ? (
+        <FlaggedItems items={flaggedItems} onSelect={setSelectedItem} />
+      ) : null}
 
       <SafeProducts items={hasWarnings ? safeItems : result.items} />
 
@@ -138,7 +153,13 @@ function SummaryStat({
   );
 }
 
-function FlaggedItems({ items }: { items: MatchedReceiptItem[] }) {
+function FlaggedItems({
+  items,
+  onSelect,
+}: {
+  items: MatchedReceiptItem[];
+  onSelect: (item: MatchedReceiptItem) => void;
+}) {
   return (
     <section>
       <p className="mb-3 font-mono text-xs uppercase text-risk">À vérifier</p>
@@ -150,6 +171,7 @@ function FlaggedItems({ items }: { items: MatchedReceiptItem[] }) {
             <button
               className="flex w-full items-center gap-3 rounded-lg border border-risk/20 bg-risk/10 p-3 text-left"
               key={item.item.id}
+              onClick={() => onSelect(item)}
               type="button"
             >
               <span className="grid size-10 shrink-0 place-items-center rounded-lg border border-risk/20 bg-card text-risk">

--- a/src/components/receipt/extraction-review.tsx
+++ b/src/components/receipt/extraction-review.tsx
@@ -17,6 +17,7 @@ import type {
   ExtractionConfidence,
   ReceiptLineItem,
 } from "@/lib/receipts/types";
+import { saveReceiptCheck } from "@/lib/receipts/history";
 import { cn } from "@/lib/utils";
 
 type ProcessingStage = "matching" | "preparing";
@@ -114,6 +115,13 @@ export function ExtractionReview({
       const nextMatchResult = (await response.json()) as RecallMatchingResult;
       setProcessingStage("preparing");
       await wait(500);
+      saveReceiptCheck({
+        id: nextMatchResult.receiptId,
+        storeName: storeName.trim() || extraction.store.name,
+        purchaseDate: purchaseDate || extraction.purchaseDate.value,
+        createdAt: nextMatchResult.matchedAt,
+        result: nextMatchResult,
+      });
       setMatchResult(nextMatchResult);
     } catch (error) {
       setMatchError(

--- a/src/components/receipt/recall-detail.tsx
+++ b/src/components/receipt/recall-detail.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { ArrowLeft, ExternalLink, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { MatchedReceiptItem } from "@/lib/recalls/matching";
+
+type RecallDetailProps = {
+  matchedItem: MatchedReceiptItem;
+  onBack: () => void;
+};
+
+export function RecallDetail({ matchedItem, onBack }: RecallDetailProps) {
+  const match = matchedItem.matches[0];
+  const recall = match.recall;
+  const lot = findLot(recall.identifiers);
+  const dateLimit = findDate(recall.identifiers) ?? recall.procedureEndsAt;
+
+  return (
+    <section className="space-y-5">
+      <div className="flex items-center gap-2">
+        <Button
+          aria-label="Retour aux résultats"
+          className="rounded-full"
+          onClick={onBack}
+          size="icon"
+          type="button"
+          variant="outline"
+        >
+          <ArrowLeft aria-hidden="true" />
+        </Button>
+        <span className="text-sm font-medium">Résultats</span>
+      </div>
+
+      <section>
+        <span className="inline-flex items-center gap-1 rounded-full bg-risk/10 px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-risk">
+          <TriangleAlert aria-hidden="true" className="size-3" />
+          Rappel en cours
+        </span>
+        <h2 className="mt-4 text-2xl font-semibold leading-tight tracking-tight">
+          {matchedItem.item.name}
+        </h2>
+        <p className="mt-2 font-mono text-xs text-muted-foreground">
+          RappelConso
+          {recall.publishedAt
+            ? ` · publié le ${formatDate(recall.publishedAt)}`
+            : ""}
+        </p>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-4 shadow-sm">
+        <InfoRow label="Produit" value={recall.productName ?? matchedItem.item.name} />
+        <InfoRow label="Marque" value={recall.brand ?? matchedItem.item.brand} />
+        <InfoRow label="Lot concerné" value={lot} />
+        <InfoRow label="DLC" value={dateLimit ? formatDate(dateLimit) : null} />
+        <InfoRow label="Motif" value={recall.reason} />
+        <InfoRow
+          label="Distribué en"
+          value={
+            recall.geographicScope ??
+            recall.distributors.slice(0, 2).join(", ") ??
+            null
+          }
+        />
+      </section>
+
+      <section>
+        <h3 className="text-lg font-semibold tracking-tight">Que faire ?</h3>
+        <div className="mt-2 space-y-1">
+          <ActionStep
+            description={
+              recall.consumerRisk
+                ? `Le rappel mentionne: ${recall.consumerRisk}. En cas de symptôme, demandez un avis médical.`
+                : "Si vous avez un doute ou des symptômes, demandez un avis médical."
+            }
+            index={1}
+            title="Ne consommez pas ce produit"
+          />
+          <ActionStep
+            description="Comparez la référence, le lot ou la date imprimée sur l'emballage avec les informations du rappel."
+            index={2}
+            title="Vérifiez le numéro de lot"
+          />
+          <ActionStep
+            description={
+              recall.recommendedActions[0] ??
+              "Suivez les consignes indiquées sur la fiche officielle RappelConso."
+            }
+            index={3}
+            title="Suivez les consignes officielles"
+          />
+        </div>
+      </section>
+
+      <div className="grid gap-3">
+        {recall.sourceUrl ? (
+          <Button asChild className="h-12">
+            <a href={recall.sourceUrl} rel="noreferrer" target="_blank">
+              Voir le rappel officiel
+              <ExternalLink aria-hidden="true" />
+            </a>
+          </Button>
+        ) : null}
+        <Button className="h-12" onClick={onBack} type="button" variant="outline">
+          Retour aux résultats
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-t border-border py-3 first:border-t-0 first:pt-0 last:pb-0">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="max-w-[58%] text-right text-sm font-medium">
+        {value || "À vérifier"}
+      </span>
+    </div>
+  );
+}
+
+function ActionStep({
+  description,
+  index,
+  title,
+}: {
+  description: string;
+  index: number;
+  title: string;
+}) {
+  return (
+    <div className="flex gap-3 py-3">
+      <span className="grid size-7 shrink-0 place-items-center rounded-full border border-border bg-card font-mono text-xs font-semibold">
+        {index}
+      </span>
+      <span>
+        <span className="block text-sm font-medium">{title}</span>
+        <span className="mt-1 block text-sm leading-6 text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function findLot(identifiers: string[]) {
+  return identifiers.find(
+    (identifier) =>
+      /lot/i.test(identifier) ||
+      (/^[a-z0-9-]{3,}$/i.test(identifier) && !/^\d{8,14}$/.test(identifier)),
+  ) ?? null;
+}
+
+function findDate(identifiers: string[]) {
+  return identifiers.find((identifier) => /^\d{4}-\d{2}-\d{2}$/.test(identifier));
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}

--- a/src/lib/receipts/history.ts
+++ b/src/lib/receipts/history.ts
@@ -1,0 +1,60 @@
+import type { RecallMatchingResult } from "@/lib/recalls/matching";
+
+export type SavedReceiptCheck = {
+  id: string;
+  storeName: string | null;
+  purchaseDate: string | null;
+  createdAt: string;
+  result: RecallMatchingResult;
+};
+
+const STORAGE_KEY = "recallradar.receiptChecks.v1";
+
+export function saveReceiptCheck(check: SavedReceiptCheck) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const existingChecks = readReceiptChecks();
+  const nextChecks = [
+    check,
+    ...existingChecks.filter((existing) => existing.id !== check.id),
+  ].slice(0, 25);
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextChecks));
+  window.dispatchEvent(new Event("recallradar:receipt-history"));
+}
+
+export function readReceiptChecks(): SavedReceiptCheck[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawChecks = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!rawChecks) {
+      return [];
+    }
+
+    const parsedChecks = JSON.parse(rawChecks);
+
+    return Array.isArray(parsedChecks) ? parsedChecks : [];
+  } catch {
+    return [];
+  }
+}
+
+export function subscribeToReceiptHistory(onStoreChange: () => void) {
+  window.addEventListener("storage", onStoreChange);
+  window.addEventListener("recallradar:receipt-history", onStoreChange);
+
+  return () => {
+    window.removeEventListener("storage", onStoreChange);
+    window.removeEventListener("recallradar:receipt-history", onStoreChange);
+  };
+}
+
+export function getReceiptHistoryServerSnapshot() {
+  return [];
+}


### PR DESCRIPTION
## Summary
- add an in-flow recall detail screen from flagged result cards with source attribution, product info rows, action guidance, official recall link, and back navigation
- save completed receipt checks to browser history after matching
- replace the history placeholder with a French mobile history list, filters, status dots, relative dates, empty state, and reopening saved results

Closes #11
Closes #12

## Validation
- bun run lint
- bun run build
- started `bun dev`; `/check` and `/history` returned HTTP 200 at `http://localhost:3001`

## Notes
- History persistence is browser-local for this V1 testing pass. The UI/data shape is ready to swap to Convex-backed persistence once we wire mutations/queries.